### PR TITLE
Fix linux generation

### DIFF
--- a/wgpu/generate.jai
+++ b/wgpu/generate.jai
@@ -81,7 +81,7 @@ ANDROID_BUILD_TARGET :: "";
             build(.LINUX, release);
 
             make_directory_if_it_does_not_exist("./linux");
-            if !copy_file(get_builded_lib_path(.LINUX, LINUX_BUILD_TARGET, release), "./windows/libwgpu_native.so") {
+            if !copy_file(get_builded_lib_path(.LINUX, LINUX_BUILD_TARGET, release), "./linux/libwgpu_native.so") {
                 log_error("Failed to copy library.");
                 exit(1);
             }


### PR DESCRIPTION
All and all it was actually just one typo.

Compiled and tested in Fedora 40, working with Jai Beta 0.1.095 and Rust 1.82.0

Will continue testing the bindings.